### PR TITLE
Add Headful browsing to Inspect's Web Tooling

### DIFF
--- a/examples/browser/compose.yaml
+++ b/examples/browser/compose.yaml
@@ -1,4 +1,11 @@
 services:
   default:
-    image: aisiuk/inspect-web-browser-tool
-    init: true
+    build:
+      context: ../../src/inspect_ai/tool/_tools/_web_browser/_resources
+      dockerfile: Dockerfile
+    ports:
+      - "5900:5900"
+    environment:
+      - HEADLESS=False
+      - DISPLAY=:99
+      - VNC_PASSWORD=...

--- a/examples/browser/compose.yaml
+++ b/examples/browser/compose.yaml
@@ -3,9 +3,6 @@ services:
     build:
       context: ../../src/inspect_ai/tool/_tools/_web_browser/_resources
       dockerfile: Dockerfile
+      target: headful
     ports:
-      - "5900:5900"
-    environment:
-      - HEADLESS=False
-      - DISPLAY=:99
-      - VNC_PASSWORD=...
+      - "127.0.0.1:5900:5900"

--- a/src/inspect_ai/tool/_tools/_web_browser/_resources/Dockerfile
+++ b/src/inspect_ai/tool/_tools/_web_browser/_resources/Dockerfile
@@ -4,20 +4,29 @@ FROM python:3.12-bookworm
 
 WORKDIR /app/web_browser
 
-RUN apt-get update
+# Install system dependancies
+RUN apt-get update \
+    && apt-get install -y \
+    xvfb \
+    x11vnc \
+    fluxbox \
+    x11-xserver-utils \
+    && rm -rf /var/lib/apt/lists/*
 
-RUN pip install --upgrade pip
+# Install python dependancies
+RUN pip install --upgrade pip \
+    && pip install playwright dm-env-rpc pillow bs4 lxml
 
-# Install playwright
-RUN pip install playwright 
-RUN playwright install
-RUN playwright install-deps 
-
-# Install other dependancies
-RUN pip install dm-env-rpc pillow bs4 lxml
+# Install playwright and dependancies
+RUN playwright install \
+    && playwright install-deps 
 
 # Copy Python files alongside the Dockerfile
 COPY *.py ./
 
-# Run the server
-CMD ["python3", "/app/web_browser/web_server.py"]
+# Copy the entrypoint script
+COPY entrypoint.sh /app/web_browser/entrypoint.sh
+RUN chmod +x /app/web_browser/entrypoint.sh
+
+# Run the entrypoint script at startup
+ENTRYPOINT [ "/app/web_browser/entrypoint.sh" ]

--- a/src/inspect_ai/tool/_tools/_web_browser/_resources/Dockerfile
+++ b/src/inspect_ai/tool/_tools/_web_browser/_resources/Dockerfile
@@ -4,7 +4,8 @@ FROM python:3.12-bookworm
 
 WORKDIR /app/web_browser
 
-# Install system dependancies
+# Install system dependancies (instead of maintaining two images, install headful dependencies
+# even though not all dependancies strictly needed in headless mode)
 RUN apt-get update \
     && apt-get install -y \
     xvfb \

--- a/src/inspect_ai/tool/_tools/_web_browser/_resources/Dockerfile
+++ b/src/inspect_ai/tool/_tools/_web_browser/_resources/Dockerfile
@@ -1,18 +1,10 @@
-# Base docker build file.
+# This Dockerfile uses a layered approach to switch between headful and headless modes.
+# To use the web_browser in headless mode, specify target: headless in your task's docker-compose
+# To use the web_browser in headful mode, specify target: headful in your task's docker-compose
+# If no target is specified, the default of headless mode is used.
 
-FROM python:3.12-bookworm
-
+FROM python:3.12-bookworm AS base
 WORKDIR /app/web_browser
-
-# Install system dependancies (instead of maintaining two images, install headful dependencies
-# even though not all dependancies strictly needed in headless mode)
-RUN apt-get update \
-    && apt-get install -y \
-    xvfb \
-    x11vnc \
-    fluxbox \
-    x11-xserver-utils \
-    && rm -rf /var/lib/apt/lists/*
 
 # Install python dependancies
 RUN pip install --upgrade pip \
@@ -31,3 +23,20 @@ RUN chmod +x /app/web_browser/entrypoint.sh
 
 # Run the entrypoint script at startup
 ENTRYPOINT [ "/app/web_browser/entrypoint.sh" ]
+
+FROM base AS headful
+ENV HEADLESS="False"
+ENV DISPLAY=:99
+EXPOSE 5900
+
+# Install system dependancies for headful browsing
+RUN apt-get update \
+    && apt-get install -y \
+    xvfb \
+    x11vnc \
+    fluxbox \
+    x11-xserver-utils \
+    && rm -rf /var/lib/apt/lists/*
+
+FROM base AS headless
+ENV HEADLESS="True"

--- a/src/inspect_ai/tool/_tools/_web_browser/_resources/dm_env_servicer.py
+++ b/src/inspect_ai/tool/_tools/_web_browser/_resources/dm_env_servicer.py
@@ -50,11 +50,15 @@ class EnvironmentSpec:
 class EnvironmentService(dm_env_rpc_pb2_grpc.EnvironmentServicer):
     """Runs the environment as a gRPC EnvironmentServicer."""
 
-    def __init__(self, env_type: Type[dm_env.Environment]) -> None:
+    def __init__(
+        self, env_type: Type[dm_env.Environment], headless: bool = True
+    ) -> None:
         """Initializes the environment.
 
         Args:
           env_type: A dm_env class to serve.
+          headless (bool): If True, web browser uses headless mode. If False, uses headful mode.
+                           Defaults to True.
         """
         self._env_type = env_type
         self._envs: dict[str, dm_env.Environment] = {}
@@ -63,6 +67,7 @@ class EnvironmentService(dm_env_rpc_pb2_grpc.EnvironmentServicer):
         self._browser: playwright_crawler.PlaywrightBrowser = None
         self._lock = threading.Lock()
         self._num_worlds = 0
+        self._headless = headless
 
     def Process(
         self,
@@ -154,7 +159,9 @@ class EnvironmentService(dm_env_rpc_pb2_grpc.EnvironmentServicer):
         world_name = _DEFAULT_WORLD_NAME
         with self._lock:
             if self._browser is None:
-                self._browser = playwright_crawler.PlaywrightBrowser()
+                self._browser = playwright_crawler.PlaywrightBrowser(
+                    headless=self._headless
+                )
             else:
                 world_name += f"_{self._num_worlds}"
             self._num_worlds += 1

--- a/src/inspect_ai/tool/_tools/_web_browser/_resources/entrypoint.sh
+++ b/src/inspect_ai/tool/_tools/_web_browser/_resources/entrypoint.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -e
 
+# If headful mode, spin up Xvfb, Fluxbox and x11vnc for real-time web browser viewing
 if [ "$HEADLESS" = "False" ]; then
 
     # Start Xvfb in the background

--- a/src/inspect_ai/tool/_tools/_web_browser/_resources/entrypoint.sh
+++ b/src/inspect_ai/tool/_tools/_web_browser/_resources/entrypoint.sh
@@ -16,7 +16,7 @@ if [ "$HEADLESS" = "False" ]; then
 
     # Start x11vnc in the background
     echo "Starting VNC server..."
-    x11vnc -display :99 -passwd ${VNC_PASSWORD} -forever -shared -verbose &
+    x11vnc -display :99 -forever -shared -verbose &
 
     # Wait for X server to be ready
     echo "Checking X server with DISPLAY=\${DISPLAY}"

--- a/src/inspect_ai/tool/_tools/_web_browser/_resources/entrypoint.sh
+++ b/src/inspect_ai/tool/_tools/_web_browser/_resources/entrypoint.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -e
+
+if [ "$HEADLESS" = "False" ]; then
+
+    # Start Xvfb in the background
+    echo "Starting Xvfb..."
+    Xvfb :99 -screen 0 1280x1024x24 -ac &
+
+    sleep 2
+
+    # Start Fluxbox in the background
+    echo "Starting Fluxbox..."
+    fluxbox &
+
+    # Start x11vnc in the background
+    echo "Starting VNC server..."
+    x11vnc -display :99 -passwd ${VNC_PASSWORD} -forever -shared -verbose &
+
+    # Wait for X server to be ready
+    echo "Checking X server with DISPLAY=\${DISPLAY}"
+    until xdpyinfo -display :99 >/dev/null 2>&1; do
+        echo "Waiting for X server..."
+        sleep 1
+    done
+    echo "X server ready"
+fi
+
+# Start the web server (runs in both headless and headful modes)
+exec python3 /app/web_browser/web_server.py

--- a/src/inspect_ai/tool/_tools/_web_browser/_resources/playwright_crawler.py
+++ b/src/inspect_ai/tool/_tools/_web_browser/_resources/playwright_crawler.py
@@ -41,15 +41,24 @@ class PlaywrightBrowser:
     HEIGHT = 1080
     _playwright_api = None
 
-    def __init__(self):
-        """Creates the browser."""
+    def __init__(self, headless: bool):
+        """
+        Creates the browser.
+
+        Args:
+            headless (bool): Defaults to True.
+                             If True, uses headless mode.
+                             If False, uses headful mode.
+        """
         if PlaywrightBrowser._playwright_api is None:
             PlaywrightBrowser._playwright_api = sync_playwright().start()
 
-        logging.info("Starting chromium in headless mode.")
+        logging.info(
+            f"Starting chromium in {'headless' if headless else 'headful'} mode."
+        )
 
         self._browser = PlaywrightBrowser._playwright_api.chromium.launch(
-            headless=True,
+            headless=headless,
             # Required for Gmail signup see
             # https://stackoverflow.com/questions/65139098/how-to-login-to-google-account-with-playwright
             args=["--disable-blink-features=AutomationControlled"],

--- a/src/inspect_ai/tool/_tools/_web_browser/_resources/playwright_crawler.py
+++ b/src/inspect_ai/tool/_tools/_web_browser/_resources/playwright_crawler.py
@@ -41,7 +41,7 @@ class PlaywrightBrowser:
     HEIGHT = 1080
     _playwright_api = None
 
-    def __init__(self, headless: bool):
+    def __init__(self, headless: bool = True):
         """
         Creates the browser.
 

--- a/src/inspect_ai/tool/_tools/_web_browser/_resources/test_playwright_crawler.py
+++ b/src/inspect_ai/tool/_tools/_web_browser/_resources/test_playwright_crawler.py
@@ -3,28 +3,49 @@ from absl.testing import parameterized
 
 
 class TestPlaywrightCrawler(parameterized.TestCase):
-    def setUp(self):
-        self._browser = playwright_crawler.PlaywrightBrowser()
+    def init_crawler(self, headless):
+        self._browser = playwright_crawler.PlaywrightBrowser(headless=headless)
         self._crawler = playwright_crawler.PlaywrightCrawler(
             self._browser.get_new_context()
         )
 
-    def test_go_to_page_changes_url(self):
+    def tearDown(self):
+        if hasattr(self, "_browser"):
+            self._browser.close()
+        super().tearDown()
+
+    @parameterized.named_parameters(
+        {"testcase_name": "_HeadlessTrue", "headless": True},
+        {"testcase_name": "_HeadlessFalse", "headless": False},
+    )
+    def test_go_to_page_changes_url(self, headless):
+        self.init_crawler(headless=headless)
         self.assertEqual(self._crawler.url, "about:blank")
         self._crawler.go_to_page("https://www.example.com")
         self.assertEqual(self._crawler.url, "https://www.example.com/")
 
-    def test_go_to_page_adds_missing_protocol(self):
+    @parameterized.named_parameters(
+        {"testcase_name": "_HeadlessTrue", "headless": True},
+        {"testcase_name": "_HeadlessFalse", "headless": False},
+    )
+    def test_go_to_page_adds_missing_protocol(self, headless):
+        self.init_crawler(headless=headless)
         self._crawler.go_to_page("www.example.com")
         self.assertEqual(self._crawler.url, "https://www.example.com/")
 
-    def test_nodes_change_on_update(self):
+    @parameterized.named_parameters(
+        {"testcase_name": "_HeadlessTrue", "headless": True},
+        {"testcase_name": "_HeadlessFalse", "headless": False},
+    )
+    def test_nodes_change_on_update(self, headless):
+        self.init_crawler(headless=headless)
         self._crawler.go_to_page("https://www.example.com")
         self.assertFalse(self._crawler._nodes)
         self._crawler.update()
         self.assertTrue(self._crawler._nodes)
 
-    def test_render_accessibility_tree(self):
+    def test_render_accessibility_tree_headless(self):
+        self.init_crawler(headless=True)
         self._crawler.go_to_page("https://www.example.com")
         at_no_update = self._crawler.render(playwright_crawler.CrawlerOutputFormat.AT)
         self.assertEqual(at_no_update, "<empty>")
@@ -50,7 +71,42 @@ class TestPlaywrightCrawler(parameterized.TestCase):
             )
         )
 
-    def test_click_adjusts_to_scrolling_position(self):
+    def test_render_accessibility_tree_headful(self):
+        """Order of AT Nodes varies more in headful browsing. Check content of nodes, not order"""
+        self.init_crawler(headless=False)
+        self._crawler.go_to_page("https://www.example.com")
+        at_no_update = self._crawler.render(playwright_crawler.CrawlerOutputFormat.AT)
+        self.assertEqual(at_no_update, "<empty>")
+
+        self._crawler.update()
+
+        at_update = self._crawler.render(playwright_crawler.CrawlerOutputFormat.AT)
+        nodes = at_update.splitlines()
+        self.assertEqual(len(nodes), 3)
+        self.assertTrue(
+            any(
+                'RootWebArea "Example Domain" [focused: True, url: https://www.example.com/]'
+                in node
+                for node in nodes
+            )
+        )
+        self.assertTrue(
+            any(
+                'StaticText "This domain is for use in illustrative examples in documents'
+                in node
+                for node in nodes
+            )
+        )
+        self.assertTrue(
+            any(
+                'link "More information..." [url: https://www.iana.org/domains/example]'
+                in node
+                for node in nodes
+            )
+        )
+
+    def test_click_adjusts_to_scrolling_position_headless(self):
+        self.init_crawler(headless=True)
         test_html = """
             <!DOCTYPE html>
             <html lang="en">
@@ -88,6 +144,59 @@ class TestPlaywrightCrawler(parameterized.TestCase):
         self.assertIn("Click Me", at_after_scroll)
 
         self._crawler.click("17")
+        self._crawler.update()
+        at_after_click = self._crawler.render(playwright_crawler.CrawlerOutputFormat.AT)
+        self.assertIn("Text Changed!", at_after_click)
+
+    def test_click_adjusts_to_scrolling_position_headful(self):
+        """Order of AT Nodes varies more in headful browsing. Check content of nodes, not order"""
+        self.init_crawler(headless=False)
+        test_html = """
+            <!DOCTYPE html>
+            <html lang="en">
+            <head>
+              <meta charset="UTF-8">
+              <title>Scrolling Test Page</title>
+              <style>
+                body { height: 3000px; }
+                .my-button { position: absolute; top: 1500px; }
+              </style>
+            </head>
+            <body>
+              <button class="my-button" onclick="changeText(this)">Click Me</button>
+              <script>
+                function changeText(button) {
+                  button.textContent = "Text Changed!";
+                }
+              </script>
+            </body>
+            </html>
+            """
+        self._crawler._page.set_content(test_html)
+        self._crawler.update()
+        at_before_scroll = self._crawler.render(
+            playwright_crawler.CrawlerOutputFormat.AT
+        )
+        self.assertIn("Scrolling Test Page", at_before_scroll)
+        self.assertNotIn("Click Me", at_before_scroll)
+
+        self._crawler.scroll("down")
+        self._crawler.update()
+        at_after_scroll = self._crawler.render(
+            playwright_crawler.CrawlerOutputFormat.AT
+        )
+        self.assertIn("Click Me", at_after_scroll)
+
+        # Find the button node ID dynamically
+        button_node_id = None
+        for node_id, node in self._crawler._nodes.items():
+            if "Click Me" in str(node):
+                button_node_id = node_id
+                break
+
+        self.assertIsNotNone(button_node_id, "Button node was not found")
+
+        self._crawler.click(button_node_id)
         self._crawler.update()
         at_after_click = self._crawler.render(playwright_crawler.CrawlerOutputFormat.AT)
         self.assertIn("Text Changed!", at_after_click)

--- a/src/inspect_ai/tool/_tools/_web_browser/_resources/web_server.py
+++ b/src/inspect_ai/tool/_tools/_web_browser/_resources/web_server.py
@@ -1,6 +1,7 @@
 """Simple script to run and test the RPC server."""
 
 from concurrent import futures
+import os
 
 import dm_env_servicer
 import grpc
@@ -27,7 +28,14 @@ def main():
         futures.ThreadPoolExecutor(max_workers=1),
         options=options,
     )
-    env_service = dm_env_servicer.EnvironmentService(web_environment.WebEnvironment)
+
+    # Read the HEADLESS environment variable to use headless or headful web browser.
+    # Defaults to true.
+    HEADLESS = os.getenv("HEADLESS", "True").lower() == "true"
+
+    env_service = dm_env_servicer.EnvironmentService(
+        web_environment.WebEnvironment, headless=HEADLESS
+    )
     dm_env_rpc_pb2_grpc.add_EnvironmentServicer_to_server(env_service, grpc_server)
 
     grpc_server.add_secure_port(


### PR DESCRIPTION
## This PR contains:
- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
The web_browser tooling only makes use of headless browser, it is not possible to view this browser graphically in real-time.

### What is the new behavior?
This PR implements headful browsing, allowing users to view an agent's interactions with the browser in real time via a VNC viewer.

Tests have been added for this new behaviour in `test_playwright_crawler`. These are essentially just parameterising playwright's headless flag to test both `True` and `False`, instead of just `True` originally. 

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
This PR should be accompanied by an update to the image (aisiuk/inspect-web-browser-tool) hosted at Dockerhub for web_browser tooling. This PR's implementation defaults to headless mode. For users making use of web_browser tooling who are not aware of this PR, there should be no downstream impacts.

### Other information:
This PR's implementation makes use of a layered Dockerfile approach, the user selects a build target in their task's docker-compose file. For example, in the `examples/browser/compose.yaml` file, the user can choose headful browsing with:

```yml
services:
  default:
    build:
      context: ../../src/inspect_ai/tool/_tools/_web_browser/_resources
      dockerfile: Dockerfile
      target: headful
    ports:
      - "127.0.0.1:5900:5900"
```

If a target is not specified, or it is specified as `headless` the Dockerfile will build the headless image. In this instance, it is not necessary to specify the 127.0.0.1:5900:5900 port mapping either (this is only needed for VNC viewing).

This PR achieves this broadly by:
* Replacing the playwright headless flag with an environment variable instead of hardcoding to `True` (i.e. the "HEADLESS" environment variable).
* Each Docker build set this "HEADLESS" environment variable depending on the target chosen by the user. The Dockerfile uses a layered approach such that only the layer's necessary for each respective build are included in the image.
* The same entrypoint.sh file is copied across into the web_browser container irrespective of target, it uses the "HEADLESS" environment variable to dictate the actions taken at container start.

Note: When running tests, a chromium browser will open/close for the headful tests, if necessary I'm open to adding decorators to these tests so they are only run when specified.
